### PR TITLE
Changed the way options are passed to the adapter constructor

### DIFF
--- a/src/Model/Database.php
+++ b/src/Model/Database.php
@@ -227,13 +227,7 @@ class Database extends AbstractModel
      */
     public function test(array $database)
     {
-        return Db::check($database['adapter'], [
-            'database' => $database['database'],
-            'username' => $database['username'],
-            'password' => $database['password'],
-            'host'     => $database['host'],
-            'type'     => $database['type'],
-        ]);
+        return Db::check($database['adapter'], array_diff_key($database, array_flip(['adapter'])));
     }
 
     /**
@@ -299,13 +293,7 @@ class Database extends AbstractModel
     public function createAdapter(array $database)
     {
         $adapter  = $database['adapter'];
-        $options  = [
-            'database' => $database['database'],
-            'username' => $database['username'],
-            'password' => $database['password'],
-            'host'     => $database['host'],
-            'type'     => $database['type']
-        ];
+        $options  = array_diff_key($database, array_flip(['adapter']));
 
         return Db::connect($adapter, $options);
     }
@@ -320,13 +308,7 @@ class Database extends AbstractModel
     public function install(array $database, $sqlFile)
     {
         $adapter  = $database['adapter'];
-        $options  = [
-            'database' => $database['database'],
-            'username' => $database['username'],
-            'password' => $database['password'],
-            'host'     => $database['host'],
-            'type'     => $database['type']
-        ];
+        $options  = array_diff_key($database, array_flip(['adapter']));
 
         Db::executeSqlFile($sqlFile, $adapter, $options);
 


### PR DESCRIPTION
Changed the way options are passed to the adapter constructor to allow you to specify other parameters, such as encoding or error handling.

Here is my standard config:

```php
[
    'adapter'  => 'pdo',
    'database' => 'database_name',
    'username' => 'root',
    'password' => 'database_password',
    'host'     => 'localhost',
    'type'     => 'mysql',
    'options'  => [
    	\PDO::ATTR_PERSISTENT => false,
    	\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES "utf8"'
    ],
    'charset'  => 'utf8',
    'collate'  => 'utf8_general_ci',
    'prefix'   => 'ob_'
]
```